### PR TITLE
fix(deps): resolve deprecation warning under Ruby 2.7

### DIFF
--- a/lib/klogger/logger.rb
+++ b/lib/klogger/logger.rb
@@ -35,10 +35,14 @@ module Klogger
     end
 
     def exception(exception, message = nil, **tags)
-      error({ message: message,
-              exception: exception.class.name,
-              exception_message: exception.message,
-              backtrace: exception.backtrace[0, 4].join("\n") }.merge(tags))
+      error(
+        **{
+          message: message,
+          exception: exception.class.name,
+          exception_message: exception.message,
+          backtrace: exception.backtrace[0, 4].join("\n")
+        }.merge(tags)
+      )
     end
 
     LEVELS.each do |level|


### PR DESCRIPTION
Ruby 3.x ended up not being fully as strict as the deprecation warnings in 2.7 hint at, but I believe it's still good to avoid deprecation warnings and ambiguity.